### PR TITLE
Draft: Twitter bot service

### DIFF
--- a/classes/twitter/__init__.py
+++ b/classes/twitter/__init__.py
@@ -1,15 +1,49 @@
 import os
 import tweepy
+import time
+from classes.assistant import Assistant
 
+PROMPT = "<PROMPT INSTRUCTIONS HERE>"
 
 class TwitterBot:
     def __init__(self):
         self.api = TwitterBot.authenticate()
     
     # Entry point for the Twitter bot
-    def start(self):
-        pass
-    
+    # After every 5 minutes, the bot will check for new mentions and respond to them
+    def start(self, since_id):        
+        since_id = 1
+        openai = Assistant(openai_api_key=os.getenv("OPEN_AI_API_KEY")).get_client()
+        
+        while True:
+            since_id = self.respond_to_mentions(since_id, openai)
+            time.sleep(300)
+ 
+    def respond_to_mentions(self, since_id, openai):
+        new_since_id = since_id
+        
+        for tweet in tweepy.Cursor(self.api.mentions_timeline, since_id=since_id).items():
+            new_since_id = max(tweet.id, new_since_id)
+            if tweet.in_reply_to_status_id is not None:
+                continue
+            
+            messages = [
+                { "role": "system", "content": PROMPT },
+                { "role": "user", "content":   tweet.text },
+            ]
+            
+            completion = openai.ChatCompletion.create(
+                model="gpt-4-1106-preview",
+                messages=messages,
+            )
+            
+            self.api.update_status(
+                status=completion.choices[0].message.content,
+                in_reply_to_status_id=tweet.id,
+            )
+            
+        return new_since_id
+                
     def authenticate() -> tweepy.API:
         auth = tweepy.OAuthHandler(os.getenv('TWITTER_CONSUMER_KEY'), os.getenv('TWITTER_CONSUMER_SECRET'))
         auth.set_access_token(os.getenv('TWITTER_ACCESS_TOKEN'), os.getenv('TWITTER_ACCESS_TOKEN'))
@@ -21,6 +55,7 @@ class TwitterBot:
             print("Authentication was successful!")
         except Exception as e:
             print(f"Authentication failed: {e}")
+            return None
             
         return api
     

--- a/st_numainda.py
+++ b/st_numainda.py
@@ -2,9 +2,6 @@ import openai
 import streamlit as st
 import time
 from classes.assistant import Assistant
-
-from dotenv import load_dotenv
-load_dotenv()
    
 assistant_id = st.secrets["ASSISTANT_ID"]
 

--- a/twitter_bot_service.py
+++ b/twitter_bot_service.py
@@ -1,0 +1,10 @@
+from dotenv import load_dotenv
+load_dotenv()
+
+from classes.twitter import TwitterBot
+
+bot = TwitterBot()
+if bot.api is None:
+    exit(1)
+    
+bot.start()


### PR DESCRIPTION
This commit introduces a preliminary draft for implementing the Twitter bot. Changes include:

- Adding a new method `respond_to_mentions` to the `TwitterBot` class, utilizing the `tweepy` API to fetch current mentions and respond to them using the ChatGPT API.
    
- Creation of `twitter_bot_service.py` containing the source code for running the bot.
    
- Updating the `start` method of the `TwitterBot` to execute a while loop every 5 minutes, invoking the `respond_to_mentions method`.

As mentioned in my previous pull request (#4) I have no way to actually test these changes since the ***Access Level*** for my current twitter API keys is not sufficient enough. Moreover I am also unaware as to how Numainda currently handles it interactions with the ChatGPT API and what instruction prompt it provides to it, so I have left that empty for now. 

Any suggestions/improvements would be appreciated!